### PR TITLE
Load theme translations after setup

### DIFF
--- a/app/setup.php
+++ b/app/setup.php
@@ -72,6 +72,11 @@ add_action('after_setup_theme', function () {
     * @link https://developer.wordpress.org/reference/functions/add_image_size/
     */
     add_image_size('xlarge', 1920);
+
+    /**
+    * Make theme available for translation.
+    */
+    load_theme_textdomain('sage', get_template_directory() . '/languages');
 }, 20);
 
 /**


### PR DESCRIPTION
Re-added a call to the `load_theme_textdomain` function that must've been accidentally removed at some point. Now the theme should make use of any `.mo` files in `resources/languages`.